### PR TITLE
ralink rt2800usb: include support for unknown (usb) devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/driver
 
 **20210405/ gkkpch**
 - Added missing RTL8188EU from Staging drivers 
+- rt2800usb: include support for unknown (usb) devices  
 
 Nanopi Neo3
 =================


### PR DESCRIPTION
Out of caution did another check on wireless support.
Also found that the Ralink RT5370 (MiniDSP's favorite for the neo3) was not working with v1.94
With this commit, wireless support should be fine with the commonly available Realtek/Broadcom/Ralink/Atheros dongles.